### PR TITLE
Fix bugs and dump a table for each region showing relative AZs to make the output easier to understand

### DIFF
--- a/script.py
+++ b/script.py
@@ -3,6 +3,10 @@ import botocore
 import boto3
 import sys
 
+# Search for reserved instances for this instance type.  Not all AZs have instances of
+# every instance type available for reservation.  By picking a very common type, we sidestep
+# that problem.  Other instance types (like m4.* or m5.*) aren't available in every AZ.
+instance_type = 't2.large'
 
 def get_input(description, default_value):
     # Ask user for input or fall back to default value
@@ -70,6 +74,7 @@ def get_reserved_instances_offering_id(client, availability_zone):
         response = client.describe_reserved_instances_offerings(
             AvailabilityZone=availability_zone,
             IncludeMarketplace=False,
+            InstanceType=instance_type,
             MaxResults=1,
         )
 


### PR DESCRIPTION
Bug fixes:

- Fix client creation so the first_account client is always used to get information for the first account.  Right now, the client on the last loop iteration is used as the client for the first iteration of the next loop
- Remove leading and trailing blanks from input entries.
- Specify an instance type in the search to avoid the issue of getting an instance type for reservation that is only available in a subset of AZs.  Often, the first reservation returned for one account is of an instance type that isn't available in every other AZ.  The t2 types seem to be available in all AZs, while not all regions (for example) have all m4 or m5 types.

Feature changes:

- Add a new feature to use all accounts configured.
- Change program to dump a table for each region.  Comment out old printouts but leave the code in there so people who want that information can uncomment it.

Minor changes:

- Fix typos.  
